### PR TITLE
Revert "Reduce CI code analysis runs"

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -3,13 +3,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - packages/**/*.ts
   pull_request:
     branches:
       - main
-    paths:
-      - packages/**/*.ts
   schedule:
     - cron: "0 7 * * 3"
 


### PR DESCRIPTION
Reverts ericcornelissen/webmangler#71, the changes causes problems when there is no analysis for the latest commit on `main` as scans cannot be compared.