### PR TITLE
Fix double counting of query selectors in JavaScript

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
+- Fix incorrect counting of certain mangled values to improve compression.
 - Support mangling CSS classes when attribute value is not quoted.
 - Support mangling CSS variables when the style attribute value is not quoted.
 - Support mangling attribute usage when the style attribute value is not quoted.

--- a/packages/core/src/languages/javascript/__tests__/query-selectors.test.ts
+++ b/packages/core/src/languages/javascript/__tests__/query-selectors.test.ts
@@ -16,7 +16,7 @@ suite("JavaScript - Query Selector Expression Factory", function() {
         {
           input: "document.querySelectorAll(\"div\");",
           pattern: "[a-z]+",
-          expected: ["div", "div"],
+          expected: ["div"],
           options: { },
         },
         {

--- a/packages/core/src/languages/javascript/index.ts
+++ b/packages/core/src/languages/javascript/index.ts
@@ -58,7 +58,7 @@ export type JavaScriptLanguagePluginOptions = {
  * });
  *
  * @since v0.1.0
- * @version v0.1.18
+ * @version v0.1.19
  */
 export default class JavaScriptLanguagePlugin extends SimpleLanguagePlugin {
   /**

--- a/packages/core/src/languages/javascript/query-selectors.ts
+++ b/packages/core/src/languages/javascript/query-selectors.ts
@@ -77,13 +77,18 @@ function newSelectorAsStandaloneStringExpression(): MangleExpression {
  * @param options The {@link QuerySelectorOptions}.
  * @returns A set of {@link MangleExpression}s.
  * @since v0.1.14
- * @version v0.1.18
+ * @version v0.1.19
  */
 export default function querySelectorExpressionFactory(
   options: QuerySelectorOptions,
 ): Iterable<MangleExpression> {
-  return [
+  const result = [
     ...newQuerySelectorExpressions(options.prefix, options.suffix),
-    newSelectorAsStandaloneStringExpression(),
   ];
+
+  if (options.suffix || options.prefix) {
+    result.push(newSelectorAsStandaloneStringExpression());
+  }
+
+  return result;
 }


### PR DESCRIPTION
Relates to: https://github.com/ericcornelissen/webmangler/issues/78