### PR TITLE
Fix unintended mangling of attribute values

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning].
 ## [Unreleased]
 
 - Fix ignored options in `BuiltInManglers` and `RecommendedManglers`.
+- Fix unintentional mangling in HTML attributes.
 
 ## [0.1.22] - 2021-06-15
 

--- a/packages/core/src/languages/html/expressions/__tests__/attributes.test.ts
+++ b/packages/core/src/languages/html/expressions/__tests__/attributes.test.ts
@@ -152,13 +152,31 @@ suite("HTML - Attribute Expression Factory", function() {
     {
       name: "attribute-like attribute values",
       pattern: "data-[a-z\\-]+",
-      expected: [],
+      expected: ["data-bar"],
       getValuesSets: () => [
         {
           tag: valuePresets.elements.tag,
           attributes: [
-            "id=\"data-praise\"",
-            "id='data-the'",
+            "id=\"data-foo\" data-bar",
+            "id='data-foo' data-bar",
+            "id=data-foo data-bar",
+          ],
+          content: valuePresets.elements.content,
+        },
+      ],
+    },
+    {
+      name: "element-like attribute values",
+      pattern: "data-[a-z\\-]+",
+      expected: ["data-bar"],
+      getValuesSets: () => [
+        {
+          tag: valuePresets.elements.tag,
+          attributes: [
+            "alt=\"<div data-foo>\" data-bar",
+            "alt='<div data-foo>' data-bar",
+            "alt=\"<div data-foo='bar'>\" data-bar",
+            "alt='<div data-foo=\"bar\">' data-bar",
           ],
           content: valuePresets.elements.content,
         },

--- a/packages/core/src/languages/html/expressions/attributes.ts
+++ b/packages/core/src/languages/html/expressions/attributes.ts
@@ -14,13 +14,13 @@ function newElementAttributeExpressions(): MangleExpression {
   return new NestedGroupMangleExpression(
     `
       (?:
-        (?:<!--.*?-->)
+        (?:<!--.*?-->|"[^"]*"|'[^']*')
         |
         (?<=\\<\\s*[a-zA-Z0-9]+\\s+)
         (?<${GROUP_MAIN}>
           (?:
             [^>\\s=]+
-            (?:\\s*=\\s*("[^"]*"|'[^']*'|[^>\\s]*))?
+            (?:\\s*=\\s*("[^"]*"|'[^']*'|[^>\\s"']*))?
             \\s+
           )*
           %s
@@ -29,9 +29,13 @@ function newElementAttributeExpressions(): MangleExpression {
       )
     `,
     `
-      (?<=\\s|^)
-      (?<${GROUP_MAIN}>%s)
-      (?=\\=|\\s|\\/|\\>|$)
+      (?:
+        (?:"[^"]*"|'[^']*')
+        |
+        (?<=\\s|^)
+        (?<${GROUP_MAIN}>%s)
+        (?=\\=|\\s|\\/|\\>|$)
+      )
     `,
     GROUP_MAIN,
   );
@@ -44,7 +48,7 @@ function newElementAttributeExpressions(): MangleExpression {
  *
  * @returns A set of {@link MangleExpression}s.
  * @since v0.1.14
- * @version v0.1.22
+ * @version v0.1.23
  */
 export default function attributeExpressionFactory():
     Iterable<MangleExpression> {

--- a/packages/core/src/languages/html/index.ts
+++ b/packages/core/src/languages/html/index.ts
@@ -67,7 +67,7 @@ export type HtmlLanguagePluginOptions = {
  *   ],
  * });
  * @since v0.1.0
- * @version v0.1.22
+ * @version v0.1.23
  */
 export default class HtmlLanguagePlugin extends SimpleLanguagePlugin {
   /**


### PR DESCRIPTION
Closes #109 

---

_**Note**: the CI for 4cffff9413cd128f78a843ab237fadbb65211b41 didn't fail because of a bug in the `npm run test` command, which has been fixed in 4fa6ac6184f5c42c8def57c38181b6d28070a682._