### PR TITLE
Improve mutation testing performance

### DIFF
--- a/packages/language-html/src/__tests__/index.test.ts
+++ b/packages/language-html/src/__tests__/index.test.ts
@@ -94,17 +94,19 @@ suite("The @webmangler/language-html plugin", function() {
 
     test("get languages", function() {
       const plugin = new HtmlLanguagePlugin();
-      const result = Array.from(plugin.getLanguages());
-      expect(result).to.include.members(DEFAULT_EXTENSIONS);
+      const result = new Set(plugin.getLanguages());
+      expect(result).to.deep.equal(new Set(DEFAULT_EXTENSIONS));
     });
 
     test("get configured languages", function() {
       const htmlExtensions = ["html5", "pug"];
 
       const plugin = new HtmlLanguagePlugin({ htmlExtensions });
-      const result = Array.from(plugin.getLanguages());
-      expect(result).to.include.members(DEFAULT_EXTENSIONS);
-      expect(result).to.include.members(htmlExtensions);
+      const result = new Set(plugin.getLanguages());
+      expect(result).to.deep.equal(new Set([
+        ...DEFAULT_EXTENSIONS,
+        ...htmlExtensions,
+      ]));
     });
   });
 });

--- a/packages/language-html/src/expressions/__tests__/single-value-attributes.test.ts
+++ b/packages/language-html/src/expressions/__tests__/single-value-attributes.test.ts
@@ -32,7 +32,7 @@ suite("HTML - Single Value Attribute Expression Factory", function() {
       name: "one element, no configuration",
       pattern: "[a-z]+",
       factoryOptions: {
-        attributeNames: ["id"],
+        attributeNames: ["id", "x-id"],
       },
       expected: ["foobar"],
       getValuesSets: () => [

--- a/stryker.config.cjs
+++ b/stryker.config.cjs
@@ -1,12 +1,16 @@
 "use strict";
 
 let packagesExpr = "*";
+let packagesList = "";
 if (process.env.TEST_PACKAGES !== undefined) {
+  const packagesArray = process.env.TEST_PACKAGES.split(",");
+
   packagesExpr = process.env.TEST_PACKAGES;
-  const packagesList = process.env.TEST_PACKAGES.split(",");
-  if (packagesList.length > 1) {
+  if (packagesArray.length > 1) {
     packagesExpr = `{${packagesExpr}}`;
   }
+
+  packagesList = packagesArray.join(" ");
 }
 
 module.exports = {
@@ -16,6 +20,12 @@ module.exports = {
     `packages/${packagesExpr}/src/**/*.ts`,
     "!**/{__mocks__,__tests__}/**/*.ts",
   ],
+  commandRunner: {
+    command: `npm run test -- ${packagesList}`,
+  },
+
+  timeoutMS: 25000,
+  timeoutFactor: 2.5,
 
   disableTypeChecks: `packages/${packagesExpr}/src/**/*.ts`,
   checkers: ["typescript"],
@@ -23,8 +33,8 @@ module.exports = {
 
   reporters: [
     "clear-text",
-    "progress",
     "html",
+    "progress",
   ],
   htmlReporter: {
     baseDir: "_reports/mutation",
@@ -35,6 +45,6 @@ module.exports = {
     break: 50,
   },
 
-  tempDirName: ".temp",
+  tempDirName: ".temp/stryker",
   cleanTempDir: false,
 };


### PR DESCRIPTION
Improve the performance of mutation tests using [StrykerJS](https://stryker-mutator.io/docs/stryker-js/introduction) by (1) reducing the number of tests run and (2) increasing the timeout.

Additionally, this re-evaluates previously mutation tested packages and improves tests where necessary in said packages.