### PR TITLE
Fix mistake in regular expressions for escaped quotes in strings

### DIFF
--- a/packages/language-css/CHANGELOG.md
+++ b/packages/language-css/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Fix issue where large chunks of CSS would not be recognized. ([#156])
 
 ## [0.1.24] - 2021-08-23
 
@@ -24,5 +24,6 @@ Versioning].
 [#138]: https://github.com/ericcornelissen/webmangler/pull/138
 [#143]: https://github.com/ericcornelissen/webmangler/pull/143
 [#151]: https://github.com/ericcornelissen/webmangler/pull/151
+[#156]: https://github.com/ericcornelissen/webmangler/pull/156
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/ "Keep a CHANGELOG"
 [semantic versioning]: https://semver.org/spec/v2.0.0.html "Semantic versioning"

--- a/packages/language-css/src/expressions/__tests__/css-values.test.ts
+++ b/packages/language-css/src/expressions/__tests__/css-values.test.ts
@@ -6,7 +6,7 @@ import { expect } from "chai";
 
 import { getAllMatches } from "./test-helpers";
 import { buildCssDeclarations, buildCssRuleset } from "./builders";
-import { valuePresets } from "./values";
+import { sampleValues, valuePresets } from "./values";
 
 import expressionsFactory from "../css-values";
 
@@ -108,6 +108,34 @@ suite("CSS - CSS Value Expression Factory", function() {
           beforeValue: valuePresets.beforeValue,
           value: ["0 3px 0 14px"],
           afterValue: valuePresets.afterValue,
+        },
+      ],
+    },
+    {
+      name: "declaration between strings and comments",
+      pattern: "[a-z]+",
+      factoryOptions: { },
+      expected: ["red"],
+      getValuesSets: () => [
+        {
+          property: ["content"],
+          value: [
+            "\"foo\"",
+            "'foo'",
+          ],
+          afterValue: sampleValues.comments,
+        },
+        {
+          property: ["color"],
+          value: ["red"],
+        },
+        {
+          beforeProperty: sampleValues.comments,
+          property: ["content"],
+          value: [
+            "\"bar\"",
+            "'bar'",
+          ],
         },
       ],
     },

--- a/packages/language-css/src/expressions/common.ts
+++ b/packages/language-css/src/expressions/common.ts
@@ -50,12 +50,12 @@ const declarationBlock = "(?:\\{[^\\}]*\\})";
 /**
  * Regular Expression pattern as a string for a double quoted string in CSS.
  */
-const doubleQuotedString = "(?:\"(?:\\\"|[^\"])*\")";
+const doubleQuotedString = "(?:\"(?:\\\\\"|[^\"])*\")";
 
 /**
  * Regular Expression pattern as a string for a single quoted string in CSS.
  */
-const singleQuotedString = "(?:'(?:\\'|[^'])*')";
+const singleQuotedString = "(?:'(?:\\\\'|[^'])*')";
 
 /**
  * Regular Expression pattern as a string for a string in CSS.


### PR DESCRIPTION
Closes #155 

As expected, the problem was indeed caused by the changes introduced in #151. The added regular expressions - as strings - `"(?:\\\")"` and `"(?:\\')"` would result in the regular expressions (resp.) `(?:\")` and `(?:\')`. These do not properly match escaped quotes in string, as it should be (resp.) `(?:\\")` and `(?:\\')` - escaping the `\` in the regular expression. This Pull Request fixes the problem and adds regression tests.