### PR TITLE
Fix `import/no-unresolved` errors about internal packages

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -119,7 +119,6 @@ module.exports = {
       ignore: [
         "webmangler/languages",
         "webmangler/manglers",
-        "webmangler/testing",
       ],
     }],
     "import/no-unused-modules": "error",

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,19 @@ jobs:
         uses: actions/checkout@v3.0.0
         with:
           fetch-depth: 0
+      - name: Cache compiled package
+        uses: actions/cache@v2.1.7
+        with:
+          path: |
+            packages/*/build
+            packages/*/lib
+            packages/*/tsconfig.tsbuildinfo
+          key: >-
+            compiled
+            all
+            ${{ hashFiles('packages/**/src/**') }}
+          restore-keys: |
+            compiled all
       - name: Fetch main branch
         if: ${{ github.ref != 'refs/heads/main' }}
         run: git fetch origin main:main
@@ -24,5 +37,7 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Compile all packages
+        run: npm run compile --workspaces
       - name: Run linters
         run: npm run lint


### PR DESCRIPTION
This issue caused some of the failed CI runs in #263 (specifically c090a989bb68af5f38697de8bf65235625fc9ce9) and #279 (specifically 810c084dff3aacaacc438ee59a3fa769aba30f8a and 031b1daccad290d937fb3124a43d8057d6bd5788).