### PR TITLE
Enforce consistent exports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -86,7 +86,7 @@ module.exports = {
     "import/export": "error",
     "import/exports-last": "error",
     "import/first": "error",
-    "import/group-exports": "off",
+    "import/group-exports": "error",
     "import/max-dependencies": "off",
     "import/named": "error",
     "import/namespace": "error",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -233,6 +233,9 @@ module.exports = {
         "space-before-blocks": "off",
 
         // See: https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules
+        "@typescript-eslint/consistent-type-exports": ["error", {
+          fixMixedExportsWithInlineTypeSpecifier: false,
+        }],
         "@typescript-eslint/consistent-type-imports": ["error", {
           prefer: "type-imports",
           disallowTypeAnnotations: false,

--- a/packages/core/src/languages/builtin/types.ts
+++ b/packages/core/src/languages/builtin/types.ts
@@ -8,7 +8,7 @@ import type { JavaScriptLanguagePluginOptions } from "@webmangler/language-js";
  *
  * @since v0.1.21
  */
-export interface BuiltInLanguagesOptions extends
+interface BuiltInLanguagesOptions extends
   CssLanguagePluginOptions,
   HtmlLanguagePluginOptions,
   JavaScriptLanguagePluginOptions { }
@@ -18,4 +18,8 @@ export interface BuiltInLanguagesOptions extends
  */
 export type WebManglerLanguagePluginClass = {
   new(options?: unknown): WebManglerLanguagePlugin;
+};
+
+export type {
+  BuiltInLanguagesOptions,
 };

--- a/packages/core/src/languages/builtin/types.ts
+++ b/packages/core/src/languages/builtin/types.ts
@@ -16,10 +16,11 @@ interface BuiltInLanguagesOptions extends
 /**
  * Type of the constructor of a {@link WebManglerLanguagePlugin}.
  */
-export type WebManglerLanguagePluginClass = {
+type WebManglerLanguagePluginClass = {
   new(options?: unknown): WebManglerLanguagePlugin;
 };
 
-export type {
+export {
   BuiltInLanguagesOptions,
+  WebManglerLanguagePluginClass,
 };

--- a/packages/core/src/languages/builtin/types.ts
+++ b/packages/core/src/languages/builtin/types.ts
@@ -20,7 +20,7 @@ type WebManglerLanguagePluginClass = {
   new(options?: unknown): WebManglerLanguagePlugin;
 };
 
-export {
+export type {
   BuiltInLanguagesOptions,
   WebManglerLanguagePluginClass,
 };


### PR DESCRIPTION
Update the ESLint configuration, updating [imports/group-exports](https://github.com/import-js/eslint-plugin-import/blob/376747914b47fbdcf99212b9e9bd4d5e09825385/docs/rules/group-exports.md) and adding [typescript-eslint/consistent-type-exports](https://github.com/typescript-eslint/typescript-eslint/blob/ce3083eab819a1628a79bec045fb0346dcbef149/packages/eslint-plugin/docs/rules/consistent-type-exports.md), to enforce consistent exports throughout all source files. In particular, all exports should now be grouped at the end of the file and `type` exports should be grouped separately. The primary reason for this is to enforce consistency and avoid questioning/discussing the style for a single/group of file(s).