### PR TITLE
Don't detect redundant embeds

### DIFF
--- a/packages/language-html/CHANGELOG.md
+++ b/packages/language-html/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning].
 ## [Unreleased]
 
 - Bump minimum `@webmangler/language-utils` version to `^0.1.27`. ([#322])
+- Improve detection of CSS embedding. ([#326])
 
 ## [0.1.26] - 2022-01-29
 
@@ -36,5 +37,6 @@ Versioning].
 [#241]: https://github.com/ericcornelissen/webmangler/pull/241
 [#250]: https://github.com/ericcornelissen/webmangler/pull/250
 [#322]: https://github.com/ericcornelissen/webmangler/pull/322
+[#326]: https://github.com/ericcornelissen/webmangler/pull/326
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/ "Keep a CHANGELOG"
 [semantic versioning]: https://semver.org/spec/v2.0.0.html "Semantic versioning"

--- a/packages/language-html/src/embeds/css/__tests__/unit/style-attribute.test.ts
+++ b/packages/language-html/src/embeds/css/__tests__/unit/style-attribute.test.ts
@@ -437,21 +437,6 @@ suite("HTML CSS Embeds - Style attribute", function() {
         {
           file: {
             type: "html",
-            content: "<div style=\" \">foobar</div>",
-          },
-          expected: [
-            {
-              content: prepareContent(" "),
-              type: EMBED_TYPE_CSS,
-              startIndex: 12,
-              endIndex: 13,
-              getRaw(): string { return " "; },
-            },
-          ],
-        },
-        {
-          file: {
-            type: "html",
             content: "< div style=\"color: red;\"><div>",
           },
           expected: [
@@ -547,6 +532,20 @@ suite("HTML CSS Embeds - Style attribute", function() {
           file: {
             type: "html",
             content: "<div style=\"\">foobar</div>",
+          },
+          expected: [],
+        },
+        {
+          file: {
+            type: "html",
+            content: "<div style=\" \">foobar</div>",
+          },
+          expected: [],
+        },
+        {
+          file: {
+            type: "html",
+            content: "<div style=\"\n\">foobar</div>",
           },
           expected: [],
         },

--- a/packages/language-html/src/embeds/css/__tests__/unit/style-tag.test.ts
+++ b/packages/language-html/src/embeds/css/__tests__/unit/style-tag.test.ts
@@ -164,21 +164,6 @@ suite("HTML CSS Embeds - <style> tag", function() {
         {
           file: {
             type: "html",
-            content: "<style> </style>",
-          },
-          expected: [
-            {
-              content: " ",
-              type: EMBED_TYPE_CSS,
-              startIndex: 7,
-              endIndex: 8,
-              getRaw(): string { return this.content; },
-            },
-          ],
-        },
-        {
-          file: {
-            type: "html",
             content: "< style>.foobar { color: red; }</style>",
           },
           expected: [
@@ -252,6 +237,20 @@ suite("HTML CSS Embeds - <style> tag", function() {
           file: {
             type: "html",
             content: "<style></style>",
+          },
+          expected: [],
+        },
+        {
+          file: {
+            type: "html",
+            content: "<style> </style>",
+          },
+          expected: [],
+        },
+        {
+          file: {
+            type: "html",
+            content: "<style>\n</style>",
           },
           expected: [],
         },

--- a/packages/language-html/src/embeds/css/style-attribute.ts
+++ b/packages/language-html/src/embeds/css/style-attribute.ts
@@ -26,7 +26,7 @@ function styleAttributeMatchToEmbed(
 
   const groups = match.groups as { [key: string]: string; };
   const declarations = groups.v;
-  if (declarations === undefined) {
+  if (declarations === undefined || /^\s*$/.test(declarations)) {
     return null;
   }
 

--- a/packages/language-html/src/embeds/css/style-tag.ts
+++ b/packages/language-html/src/embeds/css/style-tag.ts
@@ -17,7 +17,7 @@ function styleTagMatchToEmbed(match: RegExpExecArray): WebManglerEmbed | null {
   const groups = match.groups as { [key: string]: string; };
   const tag = groups.t;
   const stylesheet = groups.v;
-  if (stylesheet === undefined) {
+  if (stylesheet === undefined || /^\s*$/.test(stylesheet)) {
     return null;
   }
 

--- a/packages/language-html/src/embeds/js/__tests__/unit/script-tag.test.ts
+++ b/packages/language-html/src/embeds/js/__tests__/unit/script-tag.test.ts
@@ -164,21 +164,6 @@ suite("HTML JavaScript Embeds - <script> tag", function() {
         {
           file: {
             type: "html",
-            content: "<script> </script>",
-          },
-          expected: [
-            {
-              content: " ",
-              type: EMBED_TYPE_JS,
-              startIndex: 8,
-              endIndex: 9,
-              getRaw(): string { return this.content; },
-            },
-          ],
-        },
-        {
-          file: {
-            type: "html",
             content: "< script>var foo = \"bar\";</script>",
           },
           expected: [
@@ -252,6 +237,20 @@ suite("HTML JavaScript Embeds - <script> tag", function() {
           file: {
             type: "html",
             content: "<script></script>",
+          },
+          expected: [],
+        },
+        {
+          file: {
+            type: "html",
+            content: "<script> </script>",
+          },
+          expected: [],
+        },
+        {
+          file: {
+            type: "html",
+            content: "<script>\n</script>",
           },
           expected: [],
         },

--- a/packages/language-html/src/embeds/js/script-tag.ts
+++ b/packages/language-html/src/embeds/js/script-tag.ts
@@ -17,7 +17,7 @@ function scriptTagMatchToEmbed(match: RegExpExecArray): WebManglerEmbed | null {
   const groups = match.groups as { [key: string]: string; };
   const tag = groups.t;
   const script = groups.v;
-  if (script === undefined) {
+  if (script === undefined || /^\s*$/.test(script)) {
     return null;
   }
 


### PR DESCRIPTION
Don't detect embeds that can't possibly contain anything to mangle - i.e. embeds consisting entirely of whitespace.