### PR TITLE
Support mangling non-lowercase use of `var()`

### DIFF
--- a/packages/mangler-css-variables/CHANGELOG.md
+++ b/packages/mangler-css-variables/CHANGELOG.md
@@ -8,11 +8,12 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Fix mangling of variables when `var()` is not all-lowercase. ([#358])
 
 ## [0.1.23] - 2021-07-25
 
 - Extract the _Webmangler Core_ CSS variable mangler into this package.
 
+[#358]: https://github.com/ericcornelissen/webmangler/pull/358
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/ "Keep a CHANGELOG"
 [semantic versioning]: https://semver.org/spec/v2.0.0.html "Semantic versioning"

--- a/packages/mangler-css-variables/src/helpers/__tests__/integration/language-options.test.ts
+++ b/packages/mangler-css-variables/src/helpers/__tests__/integration/language-options.test.ts
@@ -58,7 +58,7 @@ suite("CSS Variable Mangler language-options helpers", function() {
 
     test("the `prefix` option", function() {
       const prefix = subject.options.prefix;
-      expect(prefix).to.equal("var\\s*\\(\\s*--");
+      expect(prefix).to.equal("(VAR|VAr|VaR|Var|vAR|vAr|vaR|var)\\s*\\(\\s*--");
     });
 
     test("the `suffix` option", function() {

--- a/packages/mangler-css-variables/src/helpers/__tests__/unit/language-options.test.ts
+++ b/packages/mangler-css-variables/src/helpers/__tests__/unit/language-options.test.ts
@@ -38,7 +38,7 @@ suite("CSS Variable Mangler language-options helpers", function() {
     test("the `prefix` option", function() {
       const result = getCssVariableUsageExpressionOptions();
       const prefix = result.options.prefix;
-      expect(prefix).to.equal("var\\s*\\(\\s*--");
+      expect(prefix).to.equal("(VAR|VAr|VaR|Var|vAR|vAr|vaR|var)\\s*\\(\\s*--");
     });
 
     test("the `suffix` option", function() {

--- a/packages/mangler-css-variables/src/helpers/language-options.ts
+++ b/packages/mangler-css-variables/src/helpers/language-options.ts
@@ -30,7 +30,7 @@ function getCssVariableUsageExpressionOptions():
   return {
     name: "css-declaration-values",
     options: {
-      prefix: "var\\s*\\(\\s*--",
+      prefix: "(VAR|VAr|VaR|Var|vAR|vAr|vaR|var)\\s*\\(\\s*--",
       suffix: "\\s*(,[^\\)]+)?\\)",
     },
   };


### PR DESCRIPTION
Relates to #356