### PR TITLE
Update transitive dependency `yaml`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10092,9 +10092,9 @@
       }
     },
     "node_modules/yaml-eslint-parser/node_modules/yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true,
       "engines": {
         "node": ">= 14"


### PR DESCRIPTION
Bumping because of CVE-2023-2251. Since `yaml` is only a development dependency it's not necessary to create a release for any of the packages.

```sh
$ npm ls yaml
webmangler-monorepo@0.1.0-alpha /path/to/webmangler
├─┬ commitlint@17.3.0
│ └─┬ @commitlint/cli@17.3.0
│   └─┬ @commitlint/load@17.3.0
│     └─┬ cosmiconfig@7.1.0
│       └── yaml@1.10.2
└─┬ eslint-plugin-yml@1.2.0
  └─┬ yaml-eslint-parser@1.1.0
    └── yaml@2.2.2
```