### PR TITLE
Update transitive dependency `json5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4125,9 +4125,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -6128,9 +6128,9 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"


### PR DESCRIPTION
Bumping because of CVE-2022-46175 . Since `json5` is only a development dependency it's not necessary to create a release for any of the packages.

```sh
$ npm ls json5    
webmangler-monorepo@0.1.0-alpha /path/to/webmangler
├─┬ @stryker-mutator/core@6.3.0
│ └─┬ @stryker-mutator/instrumenter@6.3.0
│   └─┬ @babel/core@7.19.0
│     └── json5@2.2.3 deduped
├─┬ eslint-plugin-import@2.26.0
│ └─┬ tsconfig-paths@3.14.1
│   └── json5@1.0.2
└─┬ tsconfig-paths@4.1.1
  └── json5@2.2.3
```