### PR TITLE
Drop explicit support for Sinon v13 and v14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11040,10 +11040,10 @@
       "version": "0.1.7",
       "license": "Unlicense",
       "engines": {
-        "node": ">=12.16.0"
+        "node": "^18 || ^20"
       },
       "peerDependencies": {
-        "sinon": "^13.0.0 || ^14.0.0 || ^15.0.0"
+        "sinon": "^15.0.0"
       }
     },
     "packages/types": {

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Drop Sinon.JS v13 and v14 support. ([#445])
 
 ## [0.1.7] - 2023-05-01
 
@@ -62,6 +62,7 @@ Versioning].
 [#253]: https://github.com/ericcornelissen/webmangler/pull/253
 [#293]: https://github.com/ericcornelissen/webmangler/pull/293
 [#433]: https://github.com/ericcornelissen/webmangler/pull/433
+[#445]: https://github.com/ericcornelissen/webmangler/pull/445
 [56b0fb6]: https://github.com/ericcornelissen/webmangler/commit/56b0fb6c3755d84d556c528610dc7387d6327b47
 [6175995]: https://github.com/ericcornelissen/webmangler/commit/617599564ec741f4b5a6ca0f47295f3db1817fb5
 [775c343]: https://github.com/ericcornelissen/webmangler/commit/775c34321bad41e9171b70ed5a33d72d793bf0f6

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -25,9 +25,9 @@
     "postpublish": "npm run clean"
   },
   "peerDependencies": {
-    "sinon": "^13.0.0 || ^14.0.0 || ^15.0.0"
+    "sinon": "^15.0.0"
   },
   "engines": {
-    "node": ">=12.16.0"
+    "node": "^18 || ^20"
   }
 }


### PR DESCRIPTION
Relates to #293, #442

## Summary

Update the `peerDependencies` of the [`testing` package](https://github.com/ericcornelissen/webmangler/tree/0b93cc1321e3cf51eab2ecf7600c4901ee8fb9ba/packages/testing) to drop support for older [Sinon.JS](https://sinonjs.org/) versions.